### PR TITLE
Add password reset via OTP

### DIFF
--- a/Model/Otp.js
+++ b/Model/Otp.js
@@ -1,0 +1,11 @@
+import mongoose from "mongoose";
+
+const otpSchema = new mongoose.Schema({
+  email: { type: String, required: true },
+  otp: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now, expires: 300 },
+});
+
+const Otp = mongoose.model("Otp", otpSchema, "otps");
+
+export default Otp;

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ import Data from "../Model/Registerdata.js";
 import Foods from "../Model/Foods.js";
 import nodemailer from "nodemailer";
 import Sessions from "../Model/Sessions.js";
+import Otp from "../Model/Otp.js";
 import useragent from "useragent";
 
 import path from "path";
@@ -505,6 +506,50 @@ app.delete("/logoutsession", verifyToken, async (req, res) => {
   } catch (error) {
     console.error("Error deleting session:", error);
     return res.status(500).json({ message: "Server error deleting session" });
+  }
+});
+
+app.post("/forgot-password", async (req, res) => {
+  const { email } = req.body;
+  try {
+    const user = await Data.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+    const otp = Math.floor(100000 + Math.random() * 900000).toString();
+    await Otp.deleteMany({ email });
+    await Otp.create({ email, otp });
+    await transporter.sendMail({
+      from: `"Fitness App" <${process.env.EMAIL_USER}>`,
+      to: email,
+      subject: "Password reset OTP",
+      html: `<p>Your OTP for password reset is <b>${otp}</b></p>`,
+    });
+    return res.status(200).json({ message: "OTP sent" });
+  } catch (err) {
+    console.error("OTP error:", err);
+    return res.status(500).json({ message: "Server error" });
+  }
+});
+
+app.post("/change-password", async (req, res) => {
+  const { email, otp, password } = req.body;
+  try {
+    const record = await Otp.findOne({ email, otp });
+    if (!record) {
+      return res.status(400).json({ message: "Invalid or expired OTP" });
+    }
+    const user = await Data.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+    user.password = await bcrypt.hash(password, 10);
+    await user.save();
+    await Otp.deleteMany({ email });
+    return res.status(200).json({ message: "Password updated" });
+  } catch (err) {
+    console.error("Change password error:", err);
+    return res.status(500).json({ message: "Server error" });
   }
 });
 

--- a/src/components/Changepassword.jsx
+++ b/src/components/Changepassword.jsx
@@ -1,0 +1,111 @@
+import React, { useState } from "react";
+import Navbar from "./Navbar";
+import { useNavigate } from "react-router-dom";
+
+function Changepassword() {
+  const [email, setEmail] = useState("");
+  const [otpSent, setOtpSent] = useState(false);
+  const [otp, setOtp] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const navigate = useNavigate();
+
+  const sendOtp = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch("http://localhost:3000/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (res.ok) {
+        setOtpSent(true);
+      } else {
+        alert("Failed to send OTP");
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const changePassword = async (e) => {
+    e.preventDefault();
+    if (password !== confirm) {
+      alert("Passwords do not match");
+      return;
+    }
+    try {
+      const res = await fetch("http://localhost:3000/change-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, otp, password }),
+      });
+      if (res.ok) {
+        alert("Password updated");
+        navigate("/signin");
+      } else {
+        const data = await res.json();
+        alert(data.message || "Error updating password");
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+      <Navbar />
+      <div className="flex w-screen items-center justify-center pt-10">
+        <form
+          onSubmit={otpSent ? changePassword : sendOtp}
+          className="flex flex-col space-y-4 bg-white/10 p-6 rounded-xl backdrop-blur-md"
+        >
+          <input
+            type="email"
+            placeholder="Email"
+            className="px-4 py-2 rounded"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          {otpSent && (
+            <>
+              <input
+                type="text"
+                placeholder="OTP"
+                className="px-4 py-2 rounded"
+                value={otp}
+                onChange={(e) => setOtp(e.target.value)}
+                required
+              />
+              <input
+                type="password"
+                placeholder="New password"
+                className="px-4 py-2 rounded"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+              <input
+                type="password"
+                placeholder="Confirm password"
+                className="px-4 py-2 rounded"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                required
+              />
+            </>
+          )}
+          <button
+            type="submit"
+            className="bg-yellow-400 text-black font-bold px-4 py-2 rounded"
+          >
+            {otpSent ? "Change Password" : "Send OTP"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default Changepassword;

--- a/src/components/Signin.jsx
+++ b/src/components/Signin.jsx
@@ -207,13 +207,22 @@ function Signin() {
                           d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                         />
                       </svg>
-                      {errors.password?.message}
-                    </div>
-                  )}
-                </div>
+                  {errors.password?.message}
+                  </div>
+                )}
+              </div>
 
-                <div className="pt-4 md:pt-6 w-full">
-                  <button
+              <div className="w-full text-right mt-2">
+                <Link
+                  to="/changepassword"
+                  className="text-yellow-400 text-xs md:text-sm hover:text-yellow-300"
+                >
+                  Forgot password?
+                </Link>
+              </div>
+
+              <div className="pt-4 md:pt-6 w-full">
+                <button
                     type="submit"
                     className="group relative w-full h-12 md:h-14 bg-gradient-to-r from-yellow-400 to-orange-500 text-black font-bold text-base md:text-lg rounded-xl shadow-2xl hover:shadow-yellow-500/25 transition-all duration-300 hover:scale-[1.02] hover:from-yellow-300 hover:to-orange-400 flex items-center justify-center"
                   >

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,6 +13,7 @@ import Activity from "./components/Activity.jsx";
 import Dashboard from "./components/Dashboard.jsx";
 import Protectedroute from "./components/Protectedroute.jsx";
 import Sessions from "./components/Sessions.jsx";
+import Changepassword from "./components/Changepassword.jsx";
 import { Navigate } from "react-router-dom";
 const token = localStorage.getItem("token");
 
@@ -25,6 +26,10 @@ const router = createBrowserRouter(
     {
       path: "/signin",
       element: <Signin />,
+    },
+    {
+      path: "/changepassword",
+      element: <Changepassword />,
     },
     {
       path: "/signup/userdata",


### PR DESCRIPTION
## Summary
- add OTP mongoose schema for password resets
- enable backend endpoints to send and verify OTPs
- add password reset link and page for changing password via OTP

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint found errors)*


------
https://chatgpt.com/codex/tasks/task_e_68b3e81845f08322a21c92c9e44253e9