### PR TITLE
fix: add ngrok bypass header

### DIFF
--- a/src/components/Activity.jsx
+++ b/src/components/Activity.jsx
@@ -14,6 +14,7 @@ function Activity() {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${localStorage.getItem("token")}`,
+        "ngrok-skip-browser-warning": "true",
       },
       body: JSON.stringify({ activity: activityLevel }),
     });

--- a/src/components/Changepassword.jsx
+++ b/src/components/Changepassword.jsx
@@ -17,7 +17,10 @@ function Changepassword() {
         "https://7ec1b82ac30b.ngrok-free.app/forgot-password",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "ngrok-skip-browser-warning": "true",
+          },
           body: JSON.stringify({ email }),
         }
       );
@@ -42,7 +45,10 @@ function Changepassword() {
         "https://7ec1b82ac30b.ngrok-free.app/change-password",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "ngrok-skip-browser-warning": "true",
+          },
           body: JSON.stringify({ email, otp, password }),
         }
       );

--- a/src/components/DNavbar.jsx
+++ b/src/components/DNavbar.jsx
@@ -13,7 +13,10 @@ function DNavbar() {
     console.log("Loggin out");
     const token = localStorage.getItem("token");
     const response = await fetch("https://7ec1b82ac30b.ngrok-free.app/logout", {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "ngrok-skip-browser-warning": "true",
+      },
     });
     localStorage.removeItem("token");
     navigate("/signin");
@@ -28,6 +31,7 @@ function DNavbar() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            "ngrok-skip-browser-warning": "true",
             // Authorization: `Bearer ${localStorage.getItem("refreshtoken")}`,
           },
           body: JSON.stringify({ refreshtoken: refreshToken }),
@@ -57,7 +61,10 @@ function DNavbar() {
           const response = await fetch(
             "https://7ec1b82ac30b.ngrok-free.app/getdata",
             {
-              headers: { Authorization: `Bearer ${token}` },
+              headers: {
+                Authorization: `Bearer ${token}`,
+                "ngrok-skip-browser-warning": "true",
+              },
             }
           );
           if (response.ok) {

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -50,7 +50,10 @@ const NutritionTracker = () => {
         const response = await fetch(
           "https://7ec1b82ac30b.ngrok-free.app/getdata",
           {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "ngrok-skip-browser-warning": "true",
+            },
           }
         );
         const data = await response.json();
@@ -74,7 +77,10 @@ const NutritionTracker = () => {
         const response = await fetch(
           "https://7ec1b82ac30b.ngrok-free.app/getfood",
           {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "ngrok-skip-browser-warning": "true",
+            },
           }
         );
         const data = await response.json();
@@ -391,6 +397,7 @@ const NutritionTracker = () => {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${localStorage.getItem("token")}`,
+          "ngrok-skip-browser-warning": "true",
         },
       });
       if (response.ok) {
@@ -412,6 +419,7 @@ const NutritionTracker = () => {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${localStorage.getItem("token")}`,
+          "ngrok-skip-browser-warning": "true",
         },
         body: JSON.stringify({ array: newfood }),
       });

--- a/src/components/Data.jsx
+++ b/src/components/Data.jsx
@@ -18,6 +18,7 @@ function Data() {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${localStorage.getItem("token")}`,
+          "ngrok-skip-browser-warning": "true",
         },
         body: JSON.stringify(data),
       });

--- a/src/components/Fatloss.jsx
+++ b/src/components/Fatloss.jsx
@@ -16,6 +16,7 @@ function Fatloss() {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${localStorage.getItem("token")}`,
+          "ngrok-skip-browser-warning": "true",
         },
         body: JSON.stringify({ mode: fatlossMode }),
       });

--- a/src/components/Goals.jsx
+++ b/src/components/Goals.jsx
@@ -39,6 +39,7 @@ function Goals() {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${localStorage.getItem("token")}`,
+          "ngrok-skip-browser-warning": "true",
         },
         body: JSON.stringify(data),
       });

--- a/src/components/Musclegain.jsx
+++ b/src/components/Musclegain.jsx
@@ -14,6 +14,7 @@ function Musclegain() {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${localStorage.getItem("token")}`,
+          "ngrok-skip-browser-warning": "true",
         },
         body: JSON.stringify({ mode: musclegainMode }),
       });

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -22,6 +22,7 @@ function Register() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            "ngrok-skip-browser-warning": "true",
           },
           body: JSON.stringify(data),
         }

--- a/src/components/Sessions.jsx
+++ b/src/components/Sessions.jsx
@@ -23,7 +23,10 @@ function Sessions() {
         const response = await fetch(
           `https://7ec1b82ac30b.ngrok-free.app/sessions?id=${decoded.userId}`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "ngrok-skip-browser-warning": "true",
+            },
           }
         );
 
@@ -50,6 +53,7 @@ function Sessions() {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${localStorage.getItem("token")}`,
+            "ngrok-skip-browser-warning": "true",
           },
         }
       );

--- a/src/components/Signin.jsx
+++ b/src/components/Signin.jsx
@@ -23,6 +23,7 @@ function Signin() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            "ngrok-skip-browser-warning": "true",
           },
           body: JSON.stringify(data),
         }


### PR DESCRIPTION
## Summary
- add `ngrok-skip-browser-warning` header to all API fetches to bypass ngrok warning page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 45 errors, 17 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b54319eaf4832289cd298d15d63739