### PR TITLE
refactor: centralize ngrok header

### DIFF
--- a/src/components/Activity.jsx
+++ b/src/components/Activity.jsx
@@ -3,13 +3,14 @@ import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
+import apiFetch from "../utils/api";
 
 function Activity() {
   const [activityLevel, setactivityLevel] = useState(0);
   let navigate = useNavigate();
 
   const sendData = async () => {
-    let response = await fetch("https://7ec1b82ac30b.ngrok-free.app/activity", {
+    let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/activity", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/components/Changepassword.jsx
+++ b/src/components/Changepassword.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Navbar from "./Navbar";
 import { useNavigate } from "react-router-dom";
+import apiFetch from "../utils/api";
 
 function Changepassword() {
   const [email, setEmail] = useState("");
@@ -13,11 +14,13 @@ function Changepassword() {
   const sendOtp = async (e) => {
     e.preventDefault();
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/forgot-password",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+          },
           body: JSON.stringify({ email }),
         }
       );
@@ -38,11 +41,13 @@ function Changepassword() {
       return;
     }
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/change-password",
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+          },
           body: JSON.stringify({ email, otp, password }),
         }
       );

--- a/src/components/DNavbar.jsx
+++ b/src/components/DNavbar.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Menu, X } from "lucide-react"; // for hamburger icons
 import { jwtDecode } from "jwt-decode";
+import apiFetch from "../utils/api";
 
 function DNavbar() {
   const navigate = useNavigate();
@@ -12,8 +13,10 @@ function DNavbar() {
   const logOut = async () => {
     console.log("Loggin out");
     const token = localStorage.getItem("token");
-    const response = await fetch("https://7ec1b82ac30b.ngrok-free.app/logout", {
-      headers: { Authorization: `Bearer ${token}` },
+    const response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/logout", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
     });
     localStorage.removeItem("token");
     navigate("/signin");
@@ -22,7 +25,7 @@ function DNavbar() {
   const refreshtoken = async () => {
     try {
       const refreshToken = localStorage.getItem("refreshtoken");
-      let response = await fetch(
+      let response = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/refresh-token",
         {
           method: "POST",
@@ -54,10 +57,12 @@ function DNavbar() {
       const fetchData = async () => {
         try {
           const token = localStorage.getItem("token");
-          const response = await fetch(
+          const response = await apiFetch(
             "https://7ec1b82ac30b.ngrok-free.app/getdata",
             {
-              headers: { Authorization: `Bearer ${token}` },
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
             }
           );
           if (response.ok) {

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import DNavbar from "./DNavbar";
 // import SDNavbar from "./SDNavbar";
+import apiFetch from "../utils/api";
 
 const NutritionTracker = () => {
   const [food, setfood] = useState([]);
@@ -47,10 +48,12 @@ const NutritionTracker = () => {
     const fetchData = async () => {
       try {
         const token = localStorage.getItem("token");
-        const response = await fetch(
+        const response = await apiFetch(
           "https://7ec1b82ac30b.ngrok-free.app/getdata",
           {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
           }
         );
         const data = await response.json();
@@ -71,10 +74,12 @@ const NutritionTracker = () => {
     const fetchFood = async () => {
       try {
         const token = localStorage.getItem("token");
-        const response = await fetch(
+        const response = await apiFetch(
           "https://7ec1b82ac30b.ngrok-free.app/getfood",
           {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
           }
         );
         const data = await response.json();
@@ -386,7 +391,7 @@ const NutritionTracker = () => {
   const [isFirstLoad, setIsFirstLoad] = useState(true);
   useEffect(() => {
     const storeData = async () => {
-      let response = await fetch("https://7ec1b82ac30b.ngrok-free.app/store", {
+      let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/store", {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -407,7 +412,7 @@ const NutritionTracker = () => {
   useEffect(() => {
     if (isFirstLoad) return;
     const storeData = async () => {
-      await fetch("https://7ec1b82ac30b.ngrok-free.app/store", {
+      await apiFetch("https://7ec1b82ac30b.ngrok-free.app/store", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/Data.jsx
+++ b/src/components/Data.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import apiFetch from "../utils/api";
 
 function Data() {
   const {
@@ -13,7 +14,7 @@ function Data() {
 
   const onSubmit = async (data) => {
     try {
-      let response = await fetch("https://7ec1b82ac30b.ngrok-free.app/data", {
+      let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/data", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/Fatloss.jsx
+++ b/src/components/Fatloss.jsx
@@ -3,6 +3,7 @@ import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
+import apiFetch from "../utils/api";
 
 function Fatloss() {
   const [fatlossMode, setfatlossMode] = useState("");
@@ -11,7 +12,7 @@ function Fatloss() {
 
   const sendData = async (data) => {
     try {
-      let response = await fetch("https://7ec1b82ac30b.ngrok-free.app/mode", {
+      let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/mode", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/Goals.jsx
+++ b/src/components/Goals.jsx
@@ -4,6 +4,7 @@ import DNavbar from "./DNavbar";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
+import apiFetch from "../utils/api";
 
 function Goals() {
   const {
@@ -34,7 +35,7 @@ function Goals() {
 
   const onSubmit = async (data) => {
     try {
-      let response = await fetch("https://7ec1b82ac30b.ngrok-free.app/goals", {
+      let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/goals", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/Musclegain.jsx
+++ b/src/components/Musclegain.jsx
@@ -3,13 +3,14 @@ import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
+import apiFetch from "../utils/api";
 
 function Musclegain() {
   const [musclegainMode, setmusclegainMode] = useState("");
   let navigate = useNavigate();
   const sendData = async () => {
     try {
-      let response = await fetch("https://7ec1b82ac30b.ngrok-free.app/mode", {
+      let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/mode", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Navbar from "./Navbar";
 import { useForm } from "react-hook-form";
 import { useNavigate, Link } from "react-router-dom";
+import apiFetch from "../utils/api";
 
 function Register() {
   const {
@@ -16,7 +17,7 @@ function Register() {
 
   const onSubmit = async (data) => {
     try {
-      let response = await fetch(
+      let response = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/register",
         {
           method: "POST",

--- a/src/components/Sessions.jsx
+++ b/src/components/Sessions.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { jwtDecode } from "jwt-decode";
 import DNavbar from "./DNavbar";
 import { LogOut } from "lucide-react";
+import apiFetch from "../utils/api";
 
 function Sessions() {
   const [sessions, setSessions] = useState([]);
@@ -20,10 +21,12 @@ function Sessions() {
         const decoded = jwtDecode(token);
         console.log("Decoded token:", decoded);
 
-        const response = await fetch(
+        const response = await apiFetch(
           `https://7ec1b82ac30b.ngrok-free.app/sessions?id=${decoded.userId}`,
           {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
           }
         );
 
@@ -43,7 +46,7 @@ function Sessions() {
 
   const logOutSession = async (id) => {
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         `https://7ec1b82ac30b.ngrok-free.app/logoutsession?id=${id}`,
         {
           method: "DELETE",

--- a/src/components/Signin.jsx
+++ b/src/components/Signin.jsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import SNavbar from "./SNavbar";
+import apiFetch from "../utils/api";
 
 function Signin() {
   const navigate = useNavigate();
@@ -17,7 +18,7 @@ function Signin() {
 
   const onSubmit = async (data) => {
     try {
-      const response = await fetch(
+      const response = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/signin",
         {
           method: "POST",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,10 @@
+export default function apiFetch(url, options = {}) {
+  const { headers = {}, ...rest } = options;
+  return fetch(url, {
+    ...rest,
+    headers: {
+      'ngrok-skip-browser-warning': 'true',
+      ...headers,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- centralize ngrok header in reusable `apiFetch`
- refactor components to use the new helper for all API calls

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 45 errors, 17 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b54319eaf4832289cd298d15d63739