### PR TITLE
feat: add reusable loader component

### DIFF
--- a/src/components/Activity.jsx
+++ b/src/components/Activity.jsx
@@ -1,15 +1,17 @@
-import React from "react";
 import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Activity() {
   const [activityLevel, setactivityLevel] = useState(0);
   let navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
 
   const sendData = async () => {
+    setLoading(true);
     let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/activity", {
       method: "POST",
       headers: {
@@ -21,6 +23,7 @@ function Activity() {
     if (response.ok) {
       console.log("Sent to DB");
     }
+    setLoading(false);
   };
   useEffect(() => {
     if (activityLevel) {
@@ -32,6 +35,7 @@ function Activity() {
 
   return (
     <div>
+      {loading && <Loader />}
       <DNavbar />
       <div className="flex">
         <SDNavbar />

--- a/src/components/Changepassword.jsx
+++ b/src/components/Changepassword.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import Navbar from "./Navbar";
 import { useNavigate } from "react-router-dom";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Changepassword() {
   const [email, setEmail] = useState("");
@@ -10,9 +11,11 @@ function Changepassword() {
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
 
   const sendOtp = async (e) => {
     e.preventDefault();
+    setLoading(true);
     try {
       const res = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/forgot-password",
@@ -31,6 +34,8 @@ function Changepassword() {
       }
     } catch (err) {
       console.error(err);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -40,6 +45,7 @@ function Changepassword() {
       alert("Passwords do not match");
       return;
     }
+    setLoading(true);
     try {
       const res = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/change-password",
@@ -60,11 +66,14 @@ function Changepassword() {
       }
     } catch (err) {
       console.error(err);
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+      {loading && <Loader />}
       <Navbar />
       <div className="flex w-screen items-center justify-center pt-10">
         <form

--- a/src/components/DNavbar.jsx
+++ b/src/components/DNavbar.jsx
@@ -1,24 +1,27 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Menu, X } from "lucide-react"; // for hamburger icons
-import { jwtDecode } from "jwt-decode";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function DNavbar() {
   const navigate = useNavigate();
   const [visible2, setvisible2] = useState(false);
   const [visible, setvisible] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const logOut = async () => {
     console.log("Loggin out");
+    setLoading(true);
     const token = localStorage.getItem("token");
-    const response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/logout", {
+    await apiFetch("https://7ec1b82ac30b.ngrok-free.app/logout", {
       headers: {
         Authorization: `Bearer ${token}`,
       },
     });
     localStorage.removeItem("token");
+    setLoading(false);
     navigate("/signin");
   };
 
@@ -92,6 +95,7 @@ function DNavbar() {
 
   return (
     <div className="relative">
+      {loading && <Loader />}
       {/* Modal for Contact/About/Guide */}
       {visible2 && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-md z-50 flex justify-center items-center">

--- a/src/components/Data.jsx
+++ b/src/components/Data.jsx
@@ -1,7 +1,8 @@
-import React from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Data() {
   const {
@@ -11,8 +12,10 @@ function Data() {
   } = useForm();
 
   const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
 
   const onSubmit = async (data) => {
+    setLoading(true);
     try {
       let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/data", {
         method: "POST",
@@ -34,11 +37,14 @@ function Data() {
     } catch (error) {
       console.error("Error:", error);
       alert("Oops! There was a problem submitting your data.");
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-4">
+      {loading && <Loader />}
       <div className="w-full max-w-md bg-gradient-to-br from-purple-900/70 to-indigo-900/70 backdrop-blur-md rounded-3xl shadow-2xl border border-white/10 overflow-hidden">
         <div className="p-2 bg-gradient-to-r from-purple-600 to-blue-600">
           <h2 className="text-white text-lg font-bold text-center py-2">

--- a/src/components/Fatloss.jsx
+++ b/src/components/Fatloss.jsx
@@ -1,16 +1,18 @@
-import React from "react";
 import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Fatloss() {
   const [fatlossMode, setfatlossMode] = useState("");
   let navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
   //   console.log(fatlossMode);
 
-  const sendData = async (data) => {
+  const sendData = async () => {
+    setLoading(true);
     try {
       let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/mode", {
         method: "POST",
@@ -26,7 +28,10 @@ function Fatloss() {
         navigate("/activity");
       }
     } catch (err) {
+      console.error(err);
       alert("A problem occured");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -42,6 +47,7 @@ function Fatloss() {
 
   return (
     <div>
+      {loading && <Loader />}
       <DNavbar />
       <div className="flex w-screen">
         <SDNavbar />

--- a/src/components/Goals.jsx
+++ b/src/components/Goals.jsx
@@ -1,10 +1,10 @@
-import React from "react";
 import { useState, useEffect } from "react";
 import DNavbar from "./DNavbar";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Goals() {
   const {
@@ -18,6 +18,7 @@ function Goals() {
 
   const navigate = useNavigate();
   const [goal, setgoal] = useState("");
+  const [loading, setLoading] = useState(false);
   useEffect(() => {
     if (selectedGoal) {
       setgoal(selectedGoal);
@@ -34,6 +35,7 @@ function Goals() {
   };
 
   const onSubmit = async (data) => {
+    setLoading(true);
     try {
       let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/goals", {
         method: "POST",
@@ -51,12 +53,16 @@ function Goals() {
         alert("An error occured from server. Login Again");
       }
     } catch (err) {
+      console.error(err);
       alert("Problem while connecting with server");
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
     <div className="h-screen bg-[#30093f] p-0 m-0 flex flex-col items-center font-dm-sans">
+      {loading && <Loader />}
       <DNavbar />
       <div className="flex w-screen">
         <SDNavbar></SDNavbar>

--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -1,0 +1,9 @@
+const Loader = () => {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="w-16 h-16 border-4 border-yellow-400/30 border-t-yellow-400 rounded-full animate-spin"></div>
+    </div>
+  );
+};
+
+export default Loader;

--- a/src/components/Musclegain.jsx
+++ b/src/components/Musclegain.jsx
@@ -1,14 +1,16 @@
-import React from "react";
 import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Musclegain() {
   const [musclegainMode, setmusclegainMode] = useState("");
   let navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
   const sendData = async () => {
+    setLoading(true);
     try {
       let response = await apiFetch("https://7ec1b82ac30b.ngrok-free.app/mode", {
         method: "POST",
@@ -24,7 +26,10 @@ function Musclegain() {
         navigate("/activity");
       }
     } catch (err) {
+      console.error(err);
       alert("A problem occured");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -38,6 +43,7 @@ function Musclegain() {
 
   return (
     <div>
+      {loading && <Loader />}
       <DNavbar />
       <div className="flex w-screen">
         <SDNavbar />

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -1,8 +1,9 @@
-import React from "react";
+import { useState } from "react";
 import Navbar from "./Navbar";
 import { useForm } from "react-hook-form";
 import { useNavigate, Link } from "react-router-dom";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Register() {
   const {
@@ -14,8 +15,10 @@ function Register() {
   } = useForm();
   const password = watch("password");
   const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
 
   const onSubmit = async (data) => {
+    setLoading(true);
     try {
       let response = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/register",
@@ -37,12 +40,16 @@ function Register() {
         });
       }
     } catch (error) {
+      console.error(error);
       alert("Oops! There occurred a problem");
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-0 m-0  items-center font-dm-sans relative overflow-hidden">
+      {loading && <Loader />}
       <Navbar />
       {/* Animated background elements */}
       <div className="absolute inset-0 overflow-hidden">

--- a/src/components/Sessions.jsx
+++ b/src/components/Sessions.jsx
@@ -1,13 +1,15 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 import { jwtDecode } from "jwt-decode";
 import DNavbar from "./DNavbar";
 import { LogOut } from "lucide-react";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Sessions() {
   const [sessions, setSessions] = useState([]);
-  const [loading, setLoading] = useState(true); // ✅ loading state
+  const [loading, setLoading] = useState(true); // initial load
+  const [actionLoading, setActionLoading] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -45,6 +47,7 @@ function Sessions() {
   }, []);
 
   const logOutSession = async (id) => {
+    setActionLoading(true);
     try {
       const response = await apiFetch(
         `https://7ec1b82ac30b.ngrok-free.app/logoutsession?id=${id}`,
@@ -66,16 +69,19 @@ function Sessions() {
     } catch (error) {
       console.error("Error deleting session:", error);
       alert("Server error");
+    } finally {
+      setActionLoading(false);
     }
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 text-white">
+      {(loading || actionLoading) && <Loader />}
       <DNavbar />
       <div className="max-w-4xl mx-auto px-6 py-10">
         <h1 className="text-3xl font-bold mb-6 text-center">Active Sessions</h1>
 
-        {/* ✅ Loading state */}
+        {/* Loading state */}
         {loading ? (
           <p className="text-center text-gray-400">Loading sessions...</p>
         ) : sessions.length === 0 ? (

--- a/src/components/Signin.jsx
+++ b/src/components/Signin.jsx
@@ -1,22 +1,23 @@
-import React from "react";
+import { useState } from "react";
 import Navbar from "./Navbar";
 import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
-import SNavbar from "./SNavbar";
 import apiFetch from "../utils/api";
+import Loader from "./Loader";
 
 function Signin() {
   const navigate = useNavigate();
   const {
     register,
     handleSubmit,
-    watch,
     setError,
     formState: { errors },
   } = useForm();
+  const [loading, setLoading] = useState(false);
 
   const onSubmit = async (data) => {
+    setLoading(true);
     try {
       const response = await apiFetch(
         "https://7ec1b82ac30b.ngrok-free.app/signin",
@@ -58,11 +59,14 @@ function Signin() {
     } catch (err) {
       alert("An error occurred. Please try again.");
       console.error(err);
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
     <>
+      {loading && <Loader />}
       <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 p-0 m-0 font-dm-sans relative overflow-hidden">
         <Navbar />
 
@@ -253,7 +257,7 @@ function Signin() {
 
                 <div className="text-center pt-3 md:pt-4">
                   <p className="text-purple-200 text-xs md:text-sm">
-                    Don't have an account?{" "}
+                    Don&apos;t have an account?{" "}
                     <Link to={"/signup"}>
                       <span className="text-yellow-400 hover:text-yellow-300 transition-colors duration-300 font-semibold underline cursor-pointer">
                         Create one now


### PR DESCRIPTION
## Summary
- add shared `<Loader />` overlay for pending operations
- show loader during sign in and other API-triggered actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/Signin.jsx src/components/Register.jsx src/components/Data.jsx src/components/Changepassword.jsx src/components/Goals.jsx src/components/Fatloss.jsx src/components/Musclegain.jsx src/components/Activity.jsx src/components/DNavbar.jsx src/components/Sessions.jsx src/components/Loader.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68b59aaa15588322ae17dfc472132931