### PR TITLE
refactor: centralize api calls with axios and env base url

### DIFF
--- a/.env
+++ b/.env
@@ -4,4 +4,5 @@
     JWT_VERIFY="MYverifyingKey"
     EMAIL_USER="izhan3008@gmail.com"
     EMAIL_PASS="tisy wwfe udfc fyld"
+    VITE_API_URL="http://localhost:5000"
     

--- a/src/components/Activity.jsx
+++ b/src/components/Activity.jsx
@@ -1,7 +1,7 @@
 import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Activity() {
@@ -12,14 +12,16 @@ function Activity() {
   const sendData = async () => {
     setLoading(true);
     try {
-      const response = await apiFetch("http://localhost:5000/activity", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ activity: activityLevel }),
-      });
+      const response = await api.post(
+        "/activity",
+        { activity: activityLevel },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }
+      );
 
       if (response.ok) {
         alert("Activity level saved successfully!");

--- a/src/components/Changepassword.jsx
+++ b/src/components/Changepassword.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import Navbar from "./Navbar";
 import { useNavigate } from "react-router-dom";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Changepassword() {
@@ -17,13 +17,15 @@ function Changepassword() {
     e.preventDefault();
     setLoading(true);
     try {
-      const res = await apiFetch("http://localhost:5000/forgot-password", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ email }),
-      });
+      const res = await api.post(
+        "/forgot-password",
+        { email },
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
       if (res.ok) {
         setOtpSent(true);
       } else {
@@ -44,18 +46,20 @@ function Changepassword() {
     }
     setLoading(true);
     try {
-      const res = await apiFetch("http://localhost:5000/change-password", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ email, otp, password }),
-      });
+      const res = await api.post(
+        "/change-password",
+        { email, otp, password },
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
       if (res.ok) {
         alert("Password updated");
         navigate("/signin");
       } else {
-        const data = await res.json();
+        const data = res.data;
         alert(data.message || "Error updating password");
       }
     } catch (err) {

--- a/src/components/DNavbar.jsx
+++ b/src/components/DNavbar.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Menu, X } from "lucide-react"; // for hamburger icons
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function DNavbar() {
@@ -15,7 +15,7 @@ function DNavbar() {
     console.log("Loggin out");
     setLoading(true);
     const token = localStorage.getItem("token");
-    await apiFetch("http://localhost:5000/logout", {
+    await api.get("/logout", {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -29,16 +29,18 @@ function DNavbar() {
     try {
       const refreshToken = localStorage.getItem("refreshtoken");
       console.log("Our refresh token : ", refreshToken);
-      let response = await apiFetch("http://localhost:5000/refresh-token", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          // Authorization: `Bearer ${localStorage.getItem("refreshtoken")}`,
-        },
-        body: JSON.stringify({ refreshtoken: refreshToken }),
-      });
+      let response = await api.post(
+        "/refresh-token",
+        { refreshtoken: refreshToken },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            // Authorization: `Bearer ${localStorage.getItem("refreshtoken")}`,
+          },
+        }
+      );
       if (response.ok) {
-        const data = await response.json();
+        const data = response.data;
         localStorage.setItem("token", data.token);
         console.log(localStorage.getItem("token"));
         console.log("Token Refreshed");
@@ -58,7 +60,7 @@ function DNavbar() {
       const fetchData = async () => {
         try {
           const token = localStorage.getItem("token");
-          const response = await apiFetch("http://localhost:5000/getdata", {
+          const response = await api.get("/getdata", {
             headers: {
               Authorization: `Bearer ${token}`,
             },

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import DNavbar from "./DNavbar";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 
 // Map activity labels (or use numeric factors directly)
 const ACTIVITY = {
@@ -103,10 +103,10 @@ const NutritionTracker = () => {
     const fetchData = async () => {
       try {
         const token = localStorage.getItem("token");
-        const res = await apiFetch("http://localhost:5000/getdata", {
+        const res = await api.get("/getdata", {
           headers: { Authorization: `Bearer ${token}` },
         });
-        const data = await res.json();
+        const data = res.data;
         if (!res.ok) {
           alert("Token expired");
           navigate("/signin");
@@ -123,10 +123,10 @@ const NutritionTracker = () => {
     const fetchFood = async () => {
       try {
         const token = localStorage.getItem("token");
-        const res = await apiFetch("http://localhost:5000/getfood", {
+        const res = await api.get("/getfood", {
           headers: { Authorization: `Bearer ${token}` },
         });
-        const data = await res.json();
+        const data = res.data;
         if (res.ok) {
           setfood(data);
           setfoodselection((prev) => [...prev, ...data]);
@@ -310,15 +310,14 @@ const NutritionTracker = () => {
   useEffect(() => {
     (async () => {
       try {
-        const res = await apiFetch("http://localhost:5000/store", {
-          method: "GET",
+        const res = await api.get("/store", {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${localStorage.getItem("token")}`,
           },
         });
         if (res.ok) {
-          const data = await res.json();
+          const data = res.data;
           setnewfood(data || []);
           setIsFirstLoad(false);
         }
@@ -333,14 +332,16 @@ const NutritionTracker = () => {
     if (isFirstLoad) return;
     (async () => {
       try {
-        await apiFetch("http://localhost:5000/store", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${localStorage.getItem("token")}`,
-          },
-          body: JSON.stringify({ array: newfood }),
-        });
+        await api.post(
+          "/store",
+          { array: newfood },
+          {
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${localStorage.getItem("token")}`,
+            },
+          }
+        );
       } catch (e) {
         console.error("POST /store error", e);
       }

--- a/src/components/Data.jsx
+++ b/src/components/Data.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Data() {
@@ -17,20 +17,22 @@ function Data() {
   const onSubmit = async (data) => {
     setLoading(true);
     try {
-      let response = await apiFetch("http://localhost:5000/data", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify(data),
-      });
+      let response = await api.post(
+        "/data",
+        data,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }
+      );
       console.log("Connected");
       if (response.ok) {
         alert("Your data has been submitted successfully!");
         navigate("/goals");
       } else if (response.status === 403) {
-        const data = await response.json();
+        const data = response.data;
         console.log("403 : ", data);
       } else {
         throw new Error("Failed to submit data");

--- a/src/components/Edit.jsx
+++ b/src/components/Edit.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import DNavbar from "./DNavbar";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 import { useNavigate } from "react-router-dom";
 
@@ -31,11 +31,11 @@ function Edit() {
     const getInfo = async () => {
       try {
         const token = localStorage.getItem("token");
-        const response = await apiFetch("http://localhost:5000/editdata", {
+        const response = await api.get("/editdata", {
           headers: { Authorization: `Bearer ${token}` },
         });
-        const resData = await response.json();
         if (!response.ok) throw new Error("Fetch failed");
+        const resData = response.data;
 
         const dateISO = resData?.date
           ? new Date(resData.date).toISOString().slice(0, 10)
@@ -102,21 +102,23 @@ function Edit() {
         // array/password/refreshtoken/verified not edited here
       };
 
-      const response = await apiFetch("http://localhost:5000/editdata", {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(payload),
-      });
+      const response = await api.put(
+        "/editdata",
+        payload,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
 
       if (!response.ok) {
-        const errText = await response.text();
-        throw new Error(errText || "Save failed");
+        const errText = response.data?.message || "Save failed";
+        throw new Error(errText);
       }
 
-      const updated = await response.json();
+      const updated = response.data;
       // reflect server truth in the form
       const next = {
         ...form,

--- a/src/components/Fatloss.jsx
+++ b/src/components/Fatloss.jsx
@@ -2,7 +2,7 @@ import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Fatloss() {
@@ -13,14 +13,16 @@ function Fatloss() {
   const sendData = async () => {
     setLoading(true);
     try {
-      const response = await apiFetch("http://localhost:5000/mode", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ mode: fatlossMode }),
-      });
+      const response = await api.post(
+        "/mode",
+        { mode: fatlossMode },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }
+      );
 
       if (response.ok) {
         alert("Mode saved successfully!");

--- a/src/components/Goals.jsx
+++ b/src/components/Goals.jsx
@@ -3,7 +3,7 @@ import DNavbar from "./DNavbar";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Goals() {
@@ -38,14 +38,16 @@ function Goals() {
   const onSubmit = async (data) => {
     setLoading(true);
     try {
-      let response = await apiFetch("http://localhost:5000/goals", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify(data),
-      });
+      let response = await api.post(
+        "/goals",
+        data,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }
+      );
       if (response.ok) {
         alert("Your goal has been submitted successfully!");
         buttonClick();

--- a/src/components/Musclegain.jsx
+++ b/src/components/Musclegain.jsx
@@ -2,7 +2,7 @@ import DNavbar from "./DNavbar";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import SDNavbar from "./SDNavbar";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Musclegain() {
@@ -13,14 +13,16 @@ function Musclegain() {
   const sendData = async () => {
     setLoading(true);
     try {
-      const response = await apiFetch("http://localhost:5000/mode", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${localStorage.getItem("token")}`,
-        },
-        body: JSON.stringify({ mode: musclegainMode }),
-      });
+      const response = await api.post(
+        "/mode",
+        { mode: musclegainMode },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("token")}`,
+          },
+        }
+      );
 
       if (response.ok) {
         alert("Mode saved successfully!");

--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import Navbar from "./Navbar";
 import { useForm } from "react-hook-form";
 import { useNavigate, Link } from "react-router-dom";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Register() {
@@ -20,13 +20,15 @@ function Register() {
   const onSubmit = async (data) => {
     setLoading(true);
     try {
-      let response = await apiFetch("http://localhost:5000/register", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      });
+      let response = await api.post(
+        "/register",
+        data,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
       if (response.ok) {
         alert("Registration Successful");
         navigate("/signin");

--- a/src/components/Sessions.jsx
+++ b/src/components/Sessions.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { jwtDecode } from "jwt-decode";
 import DNavbar from "./DNavbar";
 import { LogOut } from "lucide-react";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Sessions() {
@@ -23,8 +23,8 @@ function Sessions() {
         const decoded = jwtDecode(token);
         console.log("Decoded token:", decoded);
 
-        const response = await apiFetch(
-          `http://localhost:5000/sessions?id=${decoded.userId}`,
+        const response = await api.get(
+          `/sessions?id=${decoded.userId}`,
           {
             headers: {
               Authorization: `Bearer ${token}`,
@@ -34,7 +34,7 @@ function Sessions() {
 
         if (!response.ok) throw new Error("Failed to fetch sessions");
 
-        const data = await response.json();
+        const data = response.data;
         console.log("Fetched sessions:", data);
         console.log(data);
         setSessions(data);
@@ -49,10 +49,9 @@ function Sessions() {
   const logOutSession = async (id) => {
     setActionLoading(true);
     try {
-      const response = await apiFetch(
-        `http://localhost:5000/logoutsession?id=${id}`,
+      const response = await api.delete(
+        `/logoutsession?id=${id}`,
         {
-          method: "DELETE",
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${localStorage.getItem("token")}`,
@@ -63,7 +62,7 @@ function Sessions() {
       if (response.ok) {
         setSessions((prev) => prev.filter((s) => s._id !== id));
       } else {
-        const data = await response.json();
+        const data = response.data;
         alert(data.message || "Error deleting session");
       }
     } catch (error) {

--- a/src/components/Signin.jsx
+++ b/src/components/Signin.jsx
@@ -3,7 +3,7 @@ import Navbar from "./Navbar";
 import { useForm } from "react-hook-form";
 import { Link } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
-import apiFetch from "../utils/api";
+import api from "../utils/api";
 import Loader from "./Loader";
 
 function Signin() {
@@ -19,17 +19,19 @@ function Signin() {
   const onSubmit = async (data) => {
     setLoading(true);
     try {
-      const response = await apiFetch("http://localhost:5000/signin", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-      });
+      const response = await api.post(
+        "/signin",
+        data,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
 
       if (response.status === 302) {
         alert("Incomplete profile, redirecting...");
-        const responseData = await response.json();
+        const responseData = response.data;
         const email = responseData.email;
         localStorage.setItem("token", responseData.data.token);
         localStorage.setItem("refreshtoken", responseData.data.refresh);
@@ -38,13 +40,13 @@ function Signin() {
       }
 
       if (response.ok) {
-        const responseData = await response.json();
+        const responseData = response.data;
         localStorage.setItem("token", responseData.data.token);
         localStorage.setItem("refreshtoken", responseData.data.refresh);
         console.log(`${localStorage.getItem("refreshtoken")}`);
         navigate("/dashboard");
       } else {
-        const errorData = await response.json();
+        const errorData = response.data;
         setError("email", {
           type: "server",
           message: errorData.message || "You provided wrong data",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,10 +1,16 @@
-export default function apiFetch(url, options = {}) {
-  const { headers = {}, ...rest } = options;
-  return fetch(url, {
-    ...rest,
-    headers: {
-      "ngrok-skip-browser-warning": "true",
-      ...headers,
-    },
-  });
-}
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  headers: {
+    "ngrok-skip-browser-warning": "true",
+  },
+  validateStatus: () => true,
+});
+
+api.interceptors.response.use((response) => {
+  response.ok = response.status >= 200 && response.status < 300;
+  return response;
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- use axios instance for all API requests
- store API base url in `VITE_API_URL`
- replace fetch-based calls with axios across components

## Testing
- `npm run lint` *(fails: response is defined but never used and other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a7ae9f888322a0df1fc764fa8d07