### PR TITLE
Improve session expiry handling

### DIFF
--- a/src/components/DNavbar.jsx
+++ b/src/components/DNavbar.jsx
@@ -14,6 +14,24 @@ function DNavbar() {
   const [loading, setLoading] = useState(false);
   const isRefreshing = useRef(false);
   const refreshPromiseRef = useRef(null);
+  const sessionExpiredRef = useRef(false);
+
+  const clearStoredTokens = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("refreshtoken");
+  };
+
+  const handleSessionExpiry = () => {
+    const alreadyHandled = sessionExpiredRef.current;
+    sessionExpiredRef.current = true;
+    clearStoredTokens();
+
+    if (!alreadyHandled) {
+      alert("Session Expired");
+      setLoading(false);
+      navigate("/signin");
+    }
+  };
 
   const logOut = async () => {
     console.log("Loggin out");
@@ -26,7 +44,7 @@ function DNavbar() {
       },
       validateStatus: () => true,
     });
-    localStorage.removeItem("token");
+    clearStoredTokens();
     setLoading(false);
     navigate("/signin");
   };
@@ -56,17 +74,13 @@ function DNavbar() {
         console.log("Token refreshed successfully");
         return data.token;
       } else {
-        localStorage.removeItem("token");
         console.log("Login failed");
-        alert("Session Expired");
-        navigate("/signin");
+        handleSessionExpiry();
         return null;
       }
     } catch (err) {
       console.error("Error occurred:", err);
-      localStorage.removeItem("token");
-      alert("Session Expired");
-      navigate("/signin");
+      handleSessionExpiry();
       return null;
     }
   };

--- a/src/components/SDNavbar.jsx
+++ b/src/components/SDNavbar.jsx
@@ -8,6 +8,7 @@ function SDNavbar() {
   const navigate = useNavigate();
   const logOut = () => {
     localStorage.removeItem("token");
+    localStorage.removeItem("refreshtoken");
     navigate("/signin");
   };
   const show = () => {


### PR DESCRIPTION
## Summary
- harden the `/refresh-token` endpoint so invalid tokens clean up their session rows and return clearer errors
- centralize dashboard navbar session-expiry handling to clear both stored tokens and avoid duplicate alerts when refresh fails
- remove the cached refresh token when signing out from the small-dashboard navbar as well

## Testing
- `npm run lint` *(fails: existing lint violations unrelated to this change, e.g. missing global definitions in backend tooling files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2b2fcdb0832297ec3b0518891cd7