### PR TITLE
Switch session management to session IDs and add Google sign-in

### DIFF
--- a/Model/Registerdata.js
+++ b/Model/Registerdata.js
@@ -16,6 +16,13 @@ const dataSchema = new mongoose.Schema({
   activity: Number,
   array: Array,
   refreshtoken: String,
+  googleId: String,
+  authProvider: {
+    type: String,
+    enum: ["local", "google"],
+    default: "local",
+  },
+  avatar: String,
 });
 
 const Data = mongoose.model("Data", dataSchema, "Registeration Data");

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.4.5",
         "ejs": "^3.1.10",
         "express": "^4.21.1",
+        "google-auth-library": "^10.3.0",
         "googleapis": "^159.0.0",
         "jsonwebtoken": "^9.0.2",
         "jwt-decode": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ejs": "^3.1.10",
     "express": "^4.21.1",
     "googleapis": "^159.0.0",
+    "google-auth-library": "^10.3.0",
     "jsonwebtoken": "^9.0.2",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.542.0",

--- a/src/components/Edit.jsx
+++ b/src/components/Edit.jsx
@@ -108,7 +108,7 @@ function Edit() {
         goal: form.goal || null,
         mode: form.mode || null,
         activity: form.activity === "" ? null : Number(form.activity),
-        // array/password/refreshtoken/verified not edited here
+        // array/password/session info/verified not edited here
       };
 
       const response = await axios.put(`${API_URL}/editdata`, payload, {

--- a/src/components/SDNavbar.jsx
+++ b/src/components/SDNavbar.jsx
@@ -8,7 +8,7 @@ function SDNavbar() {
   const navigate = useNavigate();
   const logOut = () => {
     localStorage.removeItem("token");
-    localStorage.removeItem("refreshtoken");
+    localStorage.removeItem("sessionId");
     navigate("/signin");
   };
   const show = () => {

--- a/src/components/api.js
+++ b/src/components/api.js
@@ -10,12 +10,12 @@ export const api = axios.create({
 // ---- Request: attach tokens on EVERY call ----
 api.interceptors.request.use((config) => {
   const access = localStorage.getItem("token");
-  const refresh = localStorage.getItem("refreshtoken");
+  const sessionId = localStorage.getItem("sessionId");
 
   config.headers = {
     ...config.headers,
     ...(access && { Authorization: `Bearer ${access}` }),
-    ...(refresh && { "X-Refresh-Token": refresh }),
+    ...(sessionId && { "X-Session-Id": sessionId }),
     "ngrok-skip-browser-warning": "true",
   };
   return config;
@@ -67,15 +67,15 @@ api.interceptors.response.use(
         isRefreshing = true;
         refreshPromise = (async () => {
           try {
-            const refreshToken = localStorage.getItem("refreshtoken");
-            if (!refreshToken) throw new Error("No refresh token");
+            const sessionId = localStorage.getItem("sessionId");
+            if (!sessionId) throw new Error("No active session");
             const resp = await axios.post(
               `${API_URL}/refresh-token`,
-              { refreshtoken: refreshToken },
+              { sessionId },
               {
                 headers: {
                   "Content-Type": "application/json",
-                  Authorization: `Bearer ${refreshToken}`,
+                  ...(sessionId && { "X-Session-Id": sessionId }),
                   "ngrok-skip-browser-warning": "true",
                 },
               }


### PR DESCRIPTION
## Summary
- update backend authentication to identify sessions with Mongo-generated session IDs, refresh access tokens server-side, and return the new identifier on login/logout endpoints
- add a Google OAuth sign-in route and extend the user schema to persist Google profile metadata while creating sessions compatible with the new session handling
- propagate the session ID through the React app, refreshing tokens and listing sessions with the new identifier, and add a Google sign-in button that uses the backend flow

## Testing
- npm run lint *(fails: existing lint configuration reports missing global definitions and unused legacy code)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f08f9448322b726a75b58dae026