### PR TITLE
Fix Protectedroute2 to lock completed profiles

### DIFF
--- a/src/components/Proctectedroute2.jsx
+++ b/src/components/Proctectedroute2.jsx
@@ -1,29 +1,41 @@
-import React, { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import { api } from "./api";
 
 function Protectedroute2({ children }) {
   const navigate = useNavigate();
-  const API_URL = import.meta.env.VITE_API_URL;
+  const [shouldRenderChildren, setShouldRenderChildren] = useState(false);
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
+    let isActive = true;
+
     (async () => {
       try {
-        const response = await axios.get(`${API_URL}/checkData`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        console.log(response.data);
+        const response = await api.get("/checkData");
+
+        if (!isActive) return;
+
         if (response.status === 200) {
           navigate("/dashboard", { replace: true });
+        } else {
+          setShouldRenderChildren(true);
         }
       } catch (err) {
+        if (!isActive) return;
+
         console.error(err);
+        setShouldRenderChildren(true);
       }
     })();
+
+    return () => {
+      isActive = false;
+    };
   }, [navigate]);
+
+  if (!shouldRenderChildren) {
+    return null;
+  }
 
   return children;
 }


### PR DESCRIPTION
## Summary
- ensure Protectedroute2 uses the shared axios instance so authenticated requests include the session header
- prevent already completed users from re-entering onboarding routes by redirecting and hiding the protected content once completion is confirmed
- guard against state updates after unmount while waiting for the profile completion check

## Testing
- npm run lint *(fails: existing lint violations across backend/server and several components)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c9365b8c8322837bce1b9bc71586