### PR TITLE
Add debounced API search for dashboard food lookup

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -465,36 +465,59 @@ const NutritionTracker = () => {
 
   // search list
   const isSearching = useRef(false);
-  const searchItems = (input) => {
-    setsearchText(input);
-    if (!input) {
-      isSearching.current = false;
-      return setfood(originalList);
-    }
-
-    isSearching.current = true;
-    const filtered = food.filter((item) =>
-      Object.values(item).join("").toLowerCase().includes(input.toLowerCase())
-    );
-    if (filtered.length < 1) {
-      const search = async () => {
+  const debouncedApiSearch = useMemo(
+    () =>
+      debounce(async (query) => {
         try {
-          setsearching(true);
           const token = localStorage.getItem("token");
-          const response = await axios.get(`${API_URL}/search?text=${input}`, {
+          const response = await axios.get(`${API_URL}/search?text=${query}`, {
             headers: {
               Authorization: `Bearer ${token}`,
               "ngrok-skip-browser-warning": "true",
             },
           });
           setfood(response.data);
+        } catch (error) {
+          console.error("Error while searching food:", error);
         } finally {
           setsearching(false);
         }
-      };
-      search();
+      }, 400),
+    []
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedApiSearch.cancel();
+    };
+  }, [debouncedApiSearch]);
+
+  const searchItems = (input) => {
+    setsearchText(input);
+    if (!input) {
+      isSearching.current = false;
+      debouncedApiSearch.cancel();
+      setsearching(false);
+      return setfood(originalList);
     }
-    setfood(filtered);
+
+    isSearching.current = true;
+    const listToSearch = originalList.length > 0 ? originalList : food;
+    const loweredInput = input.toLowerCase();
+    const filtered = listToSearch.filter((item) =>
+      Object.values(item).join("").toLowerCase().includes(loweredInput)
+    );
+
+    if (filtered.length > 0) {
+      debouncedApiSearch.cancel();
+      setsearching(false);
+      setfood(filtered);
+      return;
+    }
+
+    setsearching(true);
+    setfood([]);
+    debouncedApiSearch(input);
   };
 
   const eatList = () => setshowList(true);


### PR DESCRIPTION
## Summary
- add a debounced API search helper in the dashboard to prevent rapid network calls while typing
- cancel any pending debounced requests when clearing the search box and fall back to the cached list when matches are available
- clear the rendered list while a remote search request is loading so only the spinner shows until results arrive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c878f9648322beca07d4999fff4d